### PR TITLE
TEC-7947 Update EBX fork to latest master version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,11 +76,8 @@ local.properties
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/**/*.xml
+*.iml
 
 # File-based project format
 *.iws

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>crawler-commons</artifactId>
 	<name>Crawler-commons</name>
 	<packaging>jar</packaging>
-	<version>1.1-SNAPSHOT</version>
+	<version>1.1-SNAPSHOT-EBX</version>
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -538,7 +538,7 @@ public class SiteMapParser {
             throw new RuntimeException("Failed to configure XML parser: " + e.toString());
         }
 
-        DelegatorHandler handler = new DelegatorHandler(sitemapUrl, strict);
+        DelegatorHandler handler = createDelegatorHandler(sitemapUrl);
         handler.setStrictNamespace(isStrictNamespace());
         if (isStrictNamespace()) {
             handler.setAcceptedNamespaces(acceptedNamespaces);
@@ -584,6 +584,17 @@ public class SiteMapParser {
         } catch (ParserConfigurationException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    /**
+     * Create delegator handler
+     *
+     * @param sitemapUrl
+     *            a sitemap {@link java.net.URL}
+     * @return the delegator handler
+     */
+    protected DelegatorHandler createDelegatorHandler(URL sitemapUrl) {
+        return new DelegatorHandler(sitemapUrl, strict);
     }
 
     /**


### PR DESCRIPTION
## [TEC-7947](https://jira.echobox.com/browse/TEC-7947)

### Spec 
N/A

### Priority
Normal

### Description of Changes
Update our fork to latest master version of https://github.com/crawler-commons/crawler-commons, can see this in https://github.com/ebx/crawler-commons.

Then also create this branch with updated version name and small update to the code so we can easily extend this logic for Google site maps in our code.

N.B. Changes to `.gitignore` were required to have a clean commit, done in a separate commit as we may not want to include these in our PR to the crawler-commons library.

### Documentation
N/A

### Risks & Impacts
Code not used at present.

### Security
N/A

### Testing
Tested code still compiles and tests still pass. Also tested `tika-core` has been removed by running:

```
mvn dependency:tree -Dverbose -Dincludes=org.apache.tika:tika-core
```

### Deployment considerations
Once updated will deploy to Archiva so that we can use in Lib and extend.